### PR TITLE
feat: ML의 얼굴벡터 추출 API를 요청하여 vector 정보도 같이 DB에 저장

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,5 +48,6 @@ jobs:
             cd apps/Marble-Server
             sudo docker stop $(sudo docker ps -a -q)
             sudo docker rm $(sudo docker ps -a -q)
+            sudo docker system prune -a -f
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}:latest
             sudo docker run --env-file .env -d -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}:latest

--- a/src/configs/typeorm.config.ts
+++ b/src/configs/typeorm.config.ts
@@ -12,6 +12,7 @@ const typeORMConfig: TypeOrmModuleOptions = {
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
   entities: [__dirname + '/../**/schemas/*.schema.{js,ts}'],
+  autoLoadEntities: true,
   synchronize: true,
   namingStrategy: new SnakeNamingStrategy(),
 };

--- a/src/image/image.controller.ts
+++ b/src/image/image.controller.ts
@@ -1,8 +1,10 @@
 import {
+  Body,
   Controller,
   Delete,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   Req,
   UploadedFile,
@@ -39,6 +41,22 @@ export class ImageController {
     @Req() req,
   ): Promise<Image> {
     return this.imageService.uploadImage(file, req.user.userId);
+  }
+
+  @ApiOperation({ summary: '얼굴 이미지 벡터 정보 수정' })
+  @ApiBody({
+    schema: {
+      properties: {
+        vector: { type: 'string' },
+      },
+    },
+  })
+  @Patch('/:imageId')
+  updateImage(
+    @Param('imageId', ParseIntPipe) imageId: number,
+    @Body('vector') vector: string,
+  ): Promise<Image> {
+    return this.imageService.updateImage(imageId, vector);
   }
 
   @ApiOperation({ summary: '얼굴 이미지 삭제' })

--- a/src/image/image.module.ts
+++ b/src/image/image.module.ts
@@ -8,6 +8,7 @@ import { MulterModule } from '@nestjs/platform-express';
 import { multerOptionsFactory } from 'src/configs/multer.options';
 import { S3ClientModule } from 'src/configs/s3Client/s3Client.module';
 import { S3ClientService } from 'src/configs/s3Client/s3Client.service';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { S3ClientService } from 'src/configs/s3Client/s3Client.service';
     TypeOrmExModule.forCustomRepository([ImageRepository]),
     UserModule,
     S3ClientModule,
+    HttpModule,
   ],
   controllers: [ImageController],
   providers: [ImageService],

--- a/src/image/image.repository.ts
+++ b/src/image/image.repository.ts
@@ -4,10 +4,15 @@ import { Repository } from 'typeorm';
 
 @CustomRepository(Image)
 export class ImageRepository extends Repository<Image> {
-  async uploadImage(url: string, userId: number): Promise<Image> {
+  async uploadImage(
+    url: string,
+    userId: number,
+    vector: string,
+  ): Promise<Image> {
     const image = this.create({
       url,
       userId,
+      vector,
     });
 
     await this.save(image);

--- a/src/image/image.service.ts
+++ b/src/image/image.service.ts
@@ -24,6 +24,13 @@ export class ImageService {
     return this.imageRepository.uploadImage(file.location, userId);
   }
 
+  async updateImage(imageId: number, vector: string): Promise<Image> {
+    const image = await this.imageRepository.findOneBy({ imageId: imageId });
+    image.vector = vector;
+    await this.imageRepository.save(image);
+    return image;
+  }
+
   async deleteImage(imageId: number): Promise<void> {
     const s3 = this.s3ClientService.s3();
     const image = await this.imageRepository.findOneBy({ imageId: imageId });

--- a/src/image/schemas/image.schema.ts
+++ b/src/image/schemas/image.schema.ts
@@ -19,8 +19,8 @@ export class Image extends BaseEntity {
   @CreateDateColumn()
   createdAt: Date;
 
-  @Column('simple-array')
-  vector: number[];
+  @Column()
+  vector: string;
 
   @ManyToOne((type) => User, (user) => user.mosaics, { eager: false })
   userId: number;

--- a/src/image/schemas/image.schema.ts
+++ b/src/image/schemas/image.schema.ts
@@ -19,7 +19,7 @@ export class Image extends BaseEntity {
   @CreateDateColumn()
   createdAt: Date;
 
-  @Column()
+  @Column('longtext')
   vector: string;
 
   @ManyToOne((type) => User, (user) => user.mosaics, { eager: false })


### PR DESCRIPTION
## 💡 이슈

resolve #15 

## 🤩 개요
얼굴 이미지 등록 시, ML의 얼굴벡터 추출 API를 요청하여 vector 정보도 같이 DB에 저장

## 🧑‍💻 작업 사항
- Image Entity에서 vector의 타입을 number[]에서 longtext로 변경
  - 사유: MySQL에서 2차원 배열을 저장할 수 없고, 문자열의 길이가 길기 때문
- 얼굴 이미지 등록 API에서, ML의 얼굴벡터 추출 API를 요청
- 받아온 vector 결과값을 string으로 변환하여 url, userId와 함께 DB에 저장
- Docker 배포 전 용량 정리하는 명령어 추가

## 📖 참고 사항
https://www.lainyzine.com/ko/article/docker-prune-usage-remove-unused-docker-objects/