### PR TITLE
hotfix: Image 엔티티 오류 수정

### DIFF
--- a/src/image/schemas/image.schema.ts
+++ b/src/image/schemas/image.schema.ts
@@ -22,6 +22,6 @@ export class Image extends BaseEntity {
   @Column('longtext')
   vector: string;
 
-  @ManyToOne((type) => User, (user) => user.mosaics, { eager: false })
+  @ManyToOne((type) => User, (user) => user.images, { eager: false })
   userId: number;
 }


### PR DESCRIPTION
## 💡 이슈
resolve #17 

## 🤩 개요
Image 엔티티 오류 수정

## 🧑‍💻 작업 사항
Image 엔티티 ManyToOne 관계 오류 수정
- user.mosaics라고 잘못 표기하여 user.images로 수정
